### PR TITLE
feat: add skip commit to the config

### DIFF
--- a/.github/workflows/supernova.yml
+++ b/.github/workflows/supernova.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           docker exec ${{ job.services.gnoland.id }} gnoland start -skip-start=true
           docker exec ${{ job.services.gnoland.id }} sed -i 's#laddr =.*:26657.*#laddr = "tcp://0.0.0.0:26657"#g' testdir/config/config.toml
+          docker exec ${{ job.services.gnoland.id }} sed -i 's#skip_timeout_commit = false#skip_timeout_commit = true"#g' testdir/config/config.toml
           docker exec -dit ${{ job.services.gnoland.id }} gnoland start
 
       - name: download supernova


### PR DESCRIPTION
## Description

This PR disables needles precommit waits at the end of the consensus process in the supernova node config, which will give real TPS results.

We should switch to using the `gnoland config` command suite in these workflows, instead of relying on `sed`. However, as a quick solution, this should be enough